### PR TITLE
Add support for parsing block-cache-size-mb

### DIFF
--- a/lib/confuse/fwup.ex
+++ b/lib/confuse/fwup.ex
@@ -34,6 +34,7 @@ defmodule Confuse.Fwup do
               specified_fwup_version: nil,
               complete_fwup_version: Version.parse!(@absolute_minimum_fwup),
               delta_fwup_version: Version.parse!(@raw_deltas_fwup),
+              block_cache_size_mb: nil,
               valid?: false
 
     @type t() :: %__MODULE__{
@@ -44,6 +45,7 @@ defmodule Confuse.Fwup do
             specified_fwup_version: Version.t() | nil,
             complete_fwup_version: Version.t(),
             delta_fwup_version: Version.t(),
+            block_cache_size_mb: non_neg_integer() | nil,
             valid?: boolean()
           }
 
@@ -171,6 +173,7 @@ defmodule Confuse.Fwup do
         |> reduce_on_resource(%{}, &check_feature/3)
         |> Map.values()
         |> Features.squash(parsed["require-fwup-version"])
+        |> then(&%{&1 | block_cache_size_mb: parsed["block-cache-size-mb"]})
 
       {:ok, output}
     end

--- a/test/fwup_test.exs
+++ b/test/fwup_test.exs
@@ -373,4 +373,39 @@ defmodule Confuse.FwupTest do
 
     assert :ok = Confuse.Fwup.validate_delta(source_conf, target_conf)
   end
+
+  test "reads block-cache-size-mb when present" do
+    conf = """
+    require-fwup-version="1.6.0"
+    block-cache-size-mb = 256
+
+    task upgrade {
+      on-resource rootfs.img {
+        delta-source-raw-offset=0
+        delta-source-raw-count=1048576
+        raw_write(0)
+      }
+    }
+    """
+
+    assert {:ok, %Confuse.Fwup.Features{block_cache_size_mb: 256}} =
+             Confuse.Fwup.get_feature_usage_from_config(conf)
+  end
+
+  test "block_cache_size_mb is nil when not specified" do
+    conf = """
+    require-fwup-version="1.6.0"
+
+    task upgrade {
+      on-resource rootfs.img {
+        delta-source-raw-offset=0
+        delta-source-raw-count=1048576
+        raw_write(0)
+      }
+    }
+    """
+
+    assert {:ok, %Confuse.Fwup.Features{block_cache_size_mb: nil}} =
+             Confuse.Fwup.get_feature_usage_from_config(conf)
+  end
 end


### PR DESCRIPTION
https://github.com/fwup-home/fwup/pull/283 has been merged!

Support pulling this config out so it can be used in places like Nerves Hub Web when generating a delta